### PR TITLE
Quantum Phase Estimation Benchmarks

### DIFF
--- a/qpexact/lsi_qpe_exact/qasm_qpeexact_3.qasm
+++ b/qpexact/lsi_qpe_exact/qasm_qpeexact_3.qasm
@@ -1,0 +1,63 @@
+OPENQASM 2.0;
+include "qelib1.inc";
+qreg q[3];
+creg c[3];
+creg meas[3];
+rz(pi/2) q[2];
+
+h q[2];
+
+rz(pi/2) q[2];
+
+h q[2];
+
+rz(3*pi/4) q[2];
+
+cx q[2],q[1];
+
+rz(-pi/4) q[1];
+
+cx q[2],q[1];
+
+rz(3*pi/4) q[1];
+rz(pi/8) q[2];
+
+h q[1];
+cx q[2],q[0];
+
+rz(-pi/8) q[0];
+rz(pi/2) q[1];
+
+h q[1];
+cx q[2],q[0];
+
+rz(pi/8) q[0];
+rz(3*pi/4) q[1];
+
+cx q[1],q[0];
+
+rz(-pi/4) q[0];
+
+cx q[1],q[0];
+
+rz(3*pi/4) q[0];
+
+h q[0];
+
+rz(pi/2) q[0];
+
+h q[0];
+
+rz(pi/2) q[0];
+
+cx q[0],q[2];
+
+cx q[2],q[0];
+
+cx q[0],q[2];
+
+
+measure q[0] -> meas[0];
+measure q[1] -> meas[1];
+measure q[2] -> meas[2];
+

--- a/qpexact/lsi_qpe_exact/qasm_qpeexact_4.qasm
+++ b/qpexact/lsi_qpe_exact/qasm_qpeexact_4.qasm
@@ -1,0 +1,96 @@
+OPENQASM 2.0;
+include "qelib1.inc";
+qreg q[3];
+qreg psi[1];
+creg c[3];
+rz(pi/2) q[0];
+rz(pi/2) q[1];
+rz(pi/2) q[2];
+x psi[0];
+
+h q[0];
+h q[1];
+h q[2];
+rz(pi/2) psi[0];
+
+rz(pi/2) q[0];
+rz(pi/2) q[1];
+rz(pi/2) q[2];
+
+h q[0];
+h q[1];
+h q[2];
+
+rz(pi/2) q[0];
+rz(pi/4) q[1];
+rz(pi/2) q[2];
+
+cx psi[0],q[0];
+
+rz(-pi/2) q[0];
+
+cx psi[0],q[0];
+
+rz(pi/2) q[0];
+
+cx q[0],q[2];
+
+cx q[2],q[0];
+
+cx q[0],q[2];
+
+rz(pi/2) q[0];
+rz(-pi/8) q[2];
+
+h q[0];
+
+rz(pi/2) q[0];
+
+h q[0];
+
+rz(pi/2) q[0];
+
+cx q[1],q[0];
+
+rz(pi/4) q[0];
+
+cx q[1],q[0];
+
+rz(-pi/4) q[0];
+rz(pi/2) q[1];
+
+h q[1];
+cx q[2],q[0];
+
+rz(pi/8) q[0];
+rz(pi/2) q[1];
+
+h q[1];
+cx q[2],q[0];
+
+rz(-pi/8) q[0];
+rz(pi/2) q[1];
+rz(-pi/4) q[2];
+
+cx q[2],q[1];
+
+rz(pi/4) q[1];
+
+cx q[2],q[1];
+
+rz(-pi/4) q[1];
+rz(pi/2) q[2];
+
+h q[2];
+
+rz(pi/2) q[2];
+
+h q[2];
+
+rz(pi/2) q[2];
+
+
+measure q[0] -> c[0];
+measure q[1] -> c[1];
+measure q[2] -> c[2];
+

--- a/qpexact/lsi_qpe_exact/qasm_qpeexact_5.qasm
+++ b/qpexact/lsi_qpe_exact/qasm_qpeexact_5.qasm
@@ -1,0 +1,161 @@
+OPENQASM 2.0;
+include "qelib1.inc";
+qreg q[4];
+qreg psi[1];
+creg c[4];
+rz(pi/2) q[0];
+rz(pi/2) q[1];
+rz(pi/2) q[2];
+rz(pi/2) q[3];
+x psi[0];
+
+h q[0];
+h q[1];
+h q[2];
+h q[3];
+rz(-7*pi/16) psi[0];
+
+rz(pi/2) q[0];
+rz(pi/2) q[1];
+rz(pi/2) q[2];
+rz(pi/2) q[3];
+
+h q[0];
+h q[1];
+h q[2];
+h q[3];
+
+rz(pi/2) q[0];
+rz(pi/2) q[1];
+rz(pi/2) q[2];
+rz(pi/2) q[3];
+
+cx psi[0],q[0];
+
+rz(7*pi/16) q[0];
+
+cx psi[0],q[0];
+
+rz(-7*pi/16) q[0];
+rz(pi/8) psi[0];
+
+cx psi[0],q[1];
+
+rz(-pi/8) q[1];
+
+cx psi[0],q[1];
+
+rz(pi/8) q[1];
+rz(pi/4) psi[0];
+
+cx psi[0],q[2];
+
+rz(-pi/4) q[2];
+
+cx psi[0],q[2];
+
+rz(pi/4) q[2];
+rz(pi/2) psi[0];
+
+cx q[1],q[2];
+cx psi[0],q[3];
+
+cx q[2],q[1];
+rz(-pi/2) q[3];
+
+cx q[1],q[2];
+cx psi[0],q[3];
+
+rz(-pi/4) q[1];
+rz(-pi/8) q[2];
+rz(pi/2) q[3];
+
+cx q[0],q[3];
+
+cx q[3],q[0];
+
+cx q[0],q[3];
+
+rz(pi/2) q[0];
+rz(-pi/16) q[3];
+
+h q[0];
+
+rz(pi/2) q[0];
+
+h q[0];
+
+rz(pi/2) q[0];
+
+cx q[1],q[0];
+
+rz(pi/4) q[0];
+
+cx q[1],q[0];
+
+rz(-pi/4) q[0];
+rz(pi/2) q[1];
+
+h q[1];
+cx q[2],q[0];
+
+rz(pi/8) q[0];
+rz(pi/2) q[1];
+
+h q[1];
+cx q[2],q[0];
+
+rz(-pi/8) q[0];
+rz(pi/2) q[1];
+rz(-pi/4) q[2];
+
+cx q[2],q[1];
+cx q[3],q[0];
+
+rz(pi/16) q[0];
+rz(pi/4) q[1];
+
+cx q[2],q[1];
+cx q[3],q[0];
+
+rz(-pi/16) q[0];
+rz(-pi/4) q[1];
+rz(pi/2) q[2];
+rz(-pi/8) q[3];
+
+h q[2];
+cx q[3],q[1];
+
+rz(pi/8) q[1];
+rz(pi/2) q[2];
+
+h q[2];
+cx q[3],q[1];
+
+rz(-pi/8) q[1];
+rz(pi/2) q[2];
+rz(-pi/4) q[3];
+
+cx q[3],q[2];
+
+rz(pi/4) q[2];
+
+cx q[3],q[2];
+
+rz(-pi/4) q[2];
+rz(pi/2) q[3];
+
+h q[3];
+
+rz(pi/2) q[3];
+
+h q[3];
+
+rz(pi/2) q[3];
+
+
+measure q[0] -> c[0];
+measure q[1] -> c[1];
+measure q[2] -> c[2];
+measure q[3] -> c[3];
+


### PR DESCRIPTION
@gwwatkin you can find the relevant qasm circuits with multiple registers in the folder, `qpexact/lsi_qpe_exact/`. These circuits have two quantum registers